### PR TITLE
Fix typos and wording

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -25,20 +25,20 @@ workflows:
     
   test_github:
     description: |-
-        It will test the danger on Github with the step's repository on Github.
+        It will test the danger on GitHub with the step's repository on GitHub.
     steps:
     - path::./:
-        title: Github test with the step repository on Github
+        title: GitHub test with the step repository on GitHub
         inputs:
         - github_api_token: $GITHUB_API_TOKEN
         run_if: true
 
   test_gitlab:
     description: |-
-        1) It will donwload the provided sample app form Gitlab.
-        2) This sample app has a danger file + gem file with a Gitlab config
-        3) It will set the PULL_REQUEST_ID for the pull request on Gitlab
-        4) It will test the danger on Gitlab with the provided GITLAB_SAMPLE_APP repository on Gitlab.
+        1) It will donwload the provided sample app form GitLab.
+        2) This sample app has a danger file + gem file with a GitLab config
+        3) It will set the PULL_REQUEST_ID for the pull request on GitLab
+        4) It will test the danger on GitLab with the provided GITLAB_SAMPLE_APP repository on GitLab.
     steps:
     - change-workdir:
         title: tmp dir
@@ -46,14 +46,14 @@ workflows:
         - path: ./_tmp
         - is_create_path: true
     - script:
-        title: Clone the sample app from Gitlab
+        title: Clone the sample app from GitLab
         inputs:
         - content: |-
             #!/bin/bash
             set -ex
             git clone -b $GITLAB_SAMPLE_APP_BRANCH $GITLAB_SAMPLE_APP .
     - script:
-        title: Set the PULL_REQUEST_ID for the pull request on Gitlab
+        title: Set the PULL_REQUEST_ID for the pull request on GitLab
         inputs:
         - content: |-
             #!/bin/bash
@@ -62,7 +62,7 @@ workflows:
             # Set the pull request id of the provided $GITLAB_SAMPLE_APP.
             envman add --key PULL_REQUEST_ID --value $GITLAB_SAMPLE_APP_PULL_REQUEST_ID
     - path::./:
-        title: "Gitlab test with the provided sample app: GITLAB_SAMPLE_APP on Gitlab"
+        title: "GitLab test with the provided sample app: GITLAB_SAMPLE_APP on GitLab"
         inputs:
         - repository_url: $GITLAB_SAMPLE_APP
         - gitlab_api_token: $GITLAB_API_TOKEN

--- a/main.go
+++ b/main.go
@@ -116,17 +116,17 @@ func main() {
 
 func validateInputs(cfg Config) {
 	if cfg.GithubAPIToken == "" && cfg.GitlabAPIToken == "" {
-		failf("None of the API token have been set.  If you want to use Github you need to set github_api_token. If you want to use Gitlab you need to set gitlab_api_token")
+		failf("None of the API token have been set.  If you want to use GitHub you need to set github_api_token. If you want to use GitLab you need to set gitlab_api_token")
 	}
 
-	// Github enterprise
+	// GitHub Enterprise
 	if (cfg.GithubHost != "" || cfg.GithubAPIBaseURL != "") && (cfg.GithubHost == "" || cfg.GithubAPIBaseURL == "") {
-		failf("If you want to use Github Enterprise you need to set both of the github_host and the github_api_base_url")
+		failf("If you want to use GitHub Enterprise you need to set both of the github_host and the github_api_base_url")
 	}
 
-	// Gitlab enterprise
+	// Self-Managed GitLab
 	if (cfg.GitlabHost != "" || cfg.GitlabAPIBaseURL != "") && (cfg.GitlabHost == "" || cfg.GitlabAPIBaseURL == "") {
-		failf("If you want to use Github Enterprise you need to set both of the gitlab_host and the gitlab_api_base_url")
+		failf("If you want to use Self-Managed GitLab you need to set both of the gitlab_host and the gitlab_api_base_url")
 	}
 
 }

--- a/step.yml
+++ b/step.yml
@@ -25,7 +25,7 @@ inputs:
 
   - github_api_token:
     opts:
-      category: Github
+      category: GitHub
       title: Access token for your project
       summary: Access token for your project
       description: |-
@@ -45,11 +45,11 @@ inputs:
       is_sensitive: true
   - github_host:
     opts:
-      category: Github
-      title: Github host
-      summary: The host that GitHub is running on. You need to set this if you are using **Enterprise Github**.
+      category: GitHub
+      title: GitHub host
+      summary: The host that GitHub is running on. You need to set this if you are using **Enterprise GitHub**.
       description: |-
-          The host that GitHub is running on. You need to set this if you are using **Enterprise Github**.
+          The host that GitHub is running on. You need to set this if you are using **Enterprise GitHub**.
           You can work with GitHub Enterprise by setting the `github_host` and the `github_api_base_url` inputs.
 
           **For example:** `git.corp.evilcorp.com`
@@ -57,11 +57,11 @@ inputs:
           **You can read more about it here:** [https://danger.systems/guides/getting_started.html](https://danger.systems/guides/getting_started.html)
   - github_api_base_url:
     opts:
-      category: Github
-      title: Github API base URL
-      summary: The host that the GitHub Enterprise API is reachable on. You need to set this if you are using **Enterprise Github**.
+      category: GitHub
+      title: GitHub API base URL
+      summary: The host that the GitHub Enterprise API is reachable on. You need to set this if you are using **Enterprise GitHub**.
       description: |-
-          The host that the GitHub Enterprise API is reachable on. You need to set this if you are using **Enterprise Github**.
+          The host that the GitHub Enterprise API is reachable on. You need to set this if you are using **Enterprise GitHub**.
           You can work with GitHub Enterprise by setting the `github_host` and the `github_api_base_url` inputs.
 
           **For example:** `https://git.corp.evilcorp.com/api/v3`
@@ -70,7 +70,7 @@ inputs:
 
   - gitlab_api_token:
     opts:
-      category: Gitlab
+      category: GitLab
       title: Access token for your project
       summary: Access token for your project
       description: |-
@@ -87,24 +87,24 @@ inputs:
       is_sensitive: true
   - gitlab_host:
     opts:
-      category: Gitlab
-      title: Gitlab host
-      summary: The host that Gitlab is running on. You need to set this if you are using **Self Hosted Gitlab**.
+      category: GitLab
+      title: GitLab host
+      summary: The host that GitLab is running on. You need to set this if you are using **Self-Managed GitLab**.
       description: |-
-          The host that Gitlab is running on. You need to set this if you are using **Self Hosted Gitlab**.
-          You can work with Self Hosted Gitlab by setting the `gitlab_host` and the `gitlab_api_base_url` inputs.
+          The host that GitLab is running on. You need to set this if you are using **Self-Managed GitLab**.
+          You can work with Self-Managed GitLab by setting the `gitlab_host` and the `gitlab_api_base_url` inputs.
 
           **For example:** `git.corp.evilcorp.com`
 
           **You can read more about it here:** [https://danger.systems/guides/getting_started.html](https://danger.systems/guides/getting_started.html)
   - gitlab_api_base_url:
     opts:
-      category: Gitlab
-      title: Gitlab API base URL
-      summary: The host that the Self Hosted Gitlab API is reachable on. You need to set this if you are using **Self Hosted Gitlab**.
+      category: GitLab
+      title: GitLab API base URL
+      summary: The host that the Self-Managed GitLab API is reachable on. You need to set this if you are using **Self-Managed GitLab**.
       description: |-
-          The host that the Self Hosted Gitlab API is reachable on. You need to set this if you are using **Self Hosted Gitlab**.
-          You can work with Self Hosted Gitlab by setting the `gitlab_host` and the `gitlab_api_base_url` inputs.
+          The host that the Self-Managed GitLab API is reachable on. You need to set this if you are using **Self-Managed GitLab**.
+          You can work with Self-Managed GitLab by setting the `gitlab_host` and the `gitlab_api_base_url` inputs.
 
           **For example:** `https://git.corp.evilcorp.com/api/v4`
 


### PR DESCRIPTION
Just a few minor typo fixes: `Github` -> `GitHub` / `Gitlab` -> `GitLab`

Also using "Self-Managed GitLab" (like on their website) instead of "self hosted".