### PR TITLE
Read bundler version from Gemfile.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,20 +3,22 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ab2f4911a4b677d56a00a2a71248ce90bd72e418e0bbd7e821673866577152c5"
+  digest = "1:7f701bf493a03c4fb4c9f22c49048b2bef8484358846d125870f6891baf3e11d"
   name = "github.com/bitrise-io/go-utils"
   packages = [
     "colorstring",
     "command",
+    "command/gems",
     "command/rubycommand",
     "errorutil",
+    "fileutil",
     "log",
     "parseutil",
     "pathutil",
     "pointers",
   ]
   pruneopts = "UT"
-  revision = "d1de0dbcb811588e61362aff67bb700b93c13c17"
+  revision = "ad86bf775472ce1934affb9d3cb7d5ea3dffd16f"
 
 [[projects]]
   branch = "master"
@@ -31,8 +33,9 @@
   analyzer-version = 1
   input-imports = [
     "github.com/bitrise-io/go-utils/command",
+    "github.com/bitrise-io/go-utils/command/gems",
     "github.com/bitrise-io/go-utils/command/rubycommand",
-    "github.com/bitrise-io/go-utils/errorutil",
+    "github.com/bitrise-io/go-utils/fileutil",
     "github.com/bitrise-io/go-utils/log",
     "github.com/bitrise-tools/go-steputils/stepconf",
   ]

--- a/vendor/github.com/bitrise-io/go-utils/command/gems/bundler.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/gems/bundler.go
@@ -1,0 +1,48 @@
+package gems
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/command/rubycommand"
+)
+
+// InstallBundlerCommand returns a command to install a specific bundler version
+func InstallBundlerCommand(gemfileLockVersion Version) *command.Model {
+	args := []string{"install", "bundler", "--force", "--no-document"}
+	if gemfileLockVersion.Found {
+		args = append(args, []string{"--version", gemfileLockVersion.Version}...)
+	}
+
+	return command.New("gem", args...)
+}
+
+// BundleInstallCommand returns a command to install a bundle using bundler
+func BundleInstallCommand(gemfileLockVersion Version) (*command.Model, error) {
+	var args []string
+	if gemfileLockVersion.Found {
+		args = append(args, "_"+gemfileLockVersion.Version+"_")
+	}
+	args = append(args, []string{"install", "--jobs", "20", "--retry", "5"}...)
+
+	return rubycommand.New("bundle", args...)
+}
+
+// BundleExecPrefix returns a slice containing: "bundle [_verson_] exec"
+func BundleExecPrefix(bundlerVersion Version) []string {
+	bundleExec := []string{"bundle"}
+	if bundlerVersion.Found {
+		bundleExec = append(bundleExec, fmt.Sprintf("_%s_", bundlerVersion.Version))
+	}
+	return append(bundleExec, "exec")
+}
+
+// RbenvVersionsCommand retruns a command to print used and available ruby versions if rbenv is installed
+func RbenvVersionsCommand() *command.Model {
+	if _, err := exec.LookPath("rbenv"); err != nil {
+		return nil
+	}
+
+	return command.New("rbenv", "versions")
+}

--- a/vendor/github.com/bitrise-io/go-utils/command/gems/gemfile_lock.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/gems/gemfile_lock.go
@@ -1,0 +1,88 @@
+package gems
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Version contains a gem version
+type Version struct {
+	Version string
+	Found   bool
+}
+
+// ParseVersionFromBundle returns the specified gem version parsed from a Gemfile.lock on a best effort basis, for logging purposes only.
+//
+// for "fastlane" and the following Gemfile.lock example, it returns: ">= 2.0)"
+//   specs:
+//     CFPropertyList (3.0.0)
+//     addressable (2.6.0)
+//       public_suffix (>= 2.0.2, < 4.0)
+//     atomos (0.1.3)
+//     babosa (1.0.2)
+//     badge (0.8.5)
+//       curb (~> 0.9)
+//       fastimage (>= 1.6)
+//       fastlane (>= 2.0)
+//       mini_magick (>= 4.5)
+//     claide (1.0.2)
+func ParseVersionFromBundle(gemName string, gemfileLockContent string) (gemVersion Version, err error) {
+	var relevantLines []string
+	lines := strings.Split(gemfileLockContent, "\n")
+
+	specsStart := false
+	for _, line := range lines {
+		if strings.Trim(line, " ") == "" {
+			specsStart = false
+		}
+
+		if strings.Contains(line, "specs:") {
+			specsStart = true
+			continue
+		}
+
+		if specsStart {
+			relevantLines = append(relevantLines, line)
+		}
+	}
+
+	//     fastlane (1.109.0)
+	exp := regexp.MustCompile(fmt.Sprintf(`^%s \((.+)\)`, regexp.QuoteMeta(gemName)))
+	for _, line := range relevantLines {
+		match := exp.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		if len(match) != 2 {
+			return Version{}, fmt.Errorf("unexpected regexp match: %v", match)
+		}
+		return Version{
+			Version: match[1],
+			Found:   true,
+		}, nil
+	}
+
+	return Version{}, nil
+}
+
+// ParseBundlerVersion returns the bundler version used to create the bundle
+func ParseBundlerVersion(gemfileLockContent string) (gemVersion Version, err error) {
+	/*
+		BUNDLED WITH
+			1.17.1
+	*/
+	bundlerRegexp := regexp.MustCompile(`(?m)^BUNDLED WITH\n\s+(\S+)`)
+	match := bundlerRegexp.FindStringSubmatch(gemfileLockContent)
+	if match == nil {
+		return Version{}, nil
+	}
+	if len(match) != 2 {
+		return Version{}, fmt.Errorf("unexpected regexp match: %v", match)
+	}
+
+	return Version{
+		Version: match[1],
+		Found:   true,
+	}, nil
+}

--- a/vendor/github.com/bitrise-io/go-utils/command/rubycommand/rubycommand.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/rubycommand/rubycommand.go
@@ -1,20 +1,20 @@
 package rubycommand
 
 import (
-	"errors"
-	"regexp"
-
 	"bufio"
 	"bytes"
-
+	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/command"
 )
 
 const (
-	systemRubyPth = "/usr/bin/ruby"
-	brewRubyPth   = "/usr/local/bin/ruby"
+	systemRubyPth  = "/usr/bin/ruby"
+	brewRubyPth    = "/usr/local/bin/ruby"
+	brewRubyPthAlt = "/usr/local/opt/ruby/bin/ruby"
 )
 
 // InstallType ...
@@ -57,6 +57,8 @@ func installType() InstallType {
 		installType = SystemRuby
 	} else if whichRuby == brewRubyPth {
 		installType = BrewRuby
+	} else if whichRuby == brewRubyPthAlt {
+		installType = BrewRuby
 	} else if cmdExist("rvm", "-v") {
 		installType = RVMRuby
 	} else if cmdExist("rbenv", "-v") {
@@ -76,10 +78,23 @@ func sudoNeeded(installType InstallType, slice ...string) bool {
 	}
 
 	name := slice[0]
-	command := slice[1]
 	if name == "bundle" {
+		command := slice[1]
+		/*
+			bundle command can contain version:
+			`bundle _2.0.1_ install`
+		*/
+		const bundleVersionMarker = "_"
+		if strings.HasPrefix(slice[1], bundleVersionMarker) && strings.HasSuffix(slice[1], bundleVersionMarker) {
+			if len(slice) < 3 {
+				return false
+			}
+			command = slice[2]
+		}
+
 		return (command == "install" || command == "update")
 	} else if name == "gem" {
+		command := slice[1]
 		return (command == "install" || command == "uninstall")
 	}
 
@@ -90,7 +105,7 @@ func sudoNeeded(installType InstallType, slice ...string) bool {
 func NewWithParams(params ...string) (*command.Model, error) {
 	rubyInstallType := installType()
 	if rubyInstallType == Unkown {
-		return nil, errors.New("unkown ruby installation type")
+		return nil, errors.New("unknown ruby installation type")
 	}
 
 	if sudoNeeded(rubyInstallType, params...) {

--- a/vendor/github.com/bitrise-io/go-utils/fileutil/fileutil.go
+++ b/vendor/github.com/bitrise-io/go-utils/fileutil/fileutil.go
@@ -1,0 +1,138 @@
+package fileutil
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+// WriteStringToFile ...
+func WriteStringToFile(pth string, fileCont string) error {
+	return WriteBytesToFile(pth, []byte(fileCont))
+}
+
+// WriteStringToFileWithPermission ...
+func WriteStringToFileWithPermission(pth string, fileCont string, perm os.FileMode) error {
+	return WriteBytesToFileWithPermission(pth, []byte(fileCont), perm)
+}
+
+// WriteBytesToFileWithPermission ...
+func WriteBytesToFileWithPermission(pth string, fileCont []byte, perm os.FileMode) error {
+	if pth == "" {
+		return errors.New("No path provided")
+	}
+
+	var file *os.File
+	var err error
+	if perm == 0 {
+		file, err = os.Create(pth)
+	} else {
+		// same as os.Create, but with a specified permission
+		//  the flags are copy-pasted from the official
+		//  os.Create func: https://golang.org/src/os/file.go?s=7327:7366#L244
+		file, err = os.OpenFile(pth, os.O_RDWR|os.O_CREATE|os.O_TRUNC, perm)
+	}
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Println(" [!] Failed to close file:", err)
+		}
+	}()
+
+	if _, err := file.Write(fileCont); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteBytesToFile ...
+func WriteBytesToFile(pth string, fileCont []byte) error {
+	return WriteBytesToFileWithPermission(pth, fileCont, 0)
+}
+
+// AppendStringToFile ...
+func AppendStringToFile(pth string, fileCont string) error {
+	return AppendBytesToFile(pth, []byte(fileCont))
+}
+
+// AppendBytesToFile ...
+func AppendBytesToFile(pth string, fileCont []byte) error {
+	if pth == "" {
+		return errors.New("No path provided")
+	}
+
+	var file *os.File
+	filePerm, err := GetFilePermissions(pth)
+	if err != nil {
+		// create the file
+		file, err = os.Create(pth)
+	} else {
+		// open for append
+		file, err = os.OpenFile(pth, os.O_APPEND|os.O_CREATE|os.O_WRONLY, filePerm)
+	}
+	if err != nil {
+		// failed to create or open-for-append the file
+		return err
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Println(" [!] Failed to close file:", err)
+		}
+	}()
+
+	if _, err := file.Write(fileCont); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ReadBytesFromFile ...
+func ReadBytesFromFile(pth string) ([]byte, error) {
+	if isExists, err := pathutil.IsPathExists(pth); err != nil {
+		return []byte{}, err
+	} else if !isExists {
+		return []byte{}, fmt.Errorf("No file found at path: %s", pth)
+	}
+
+	bytes, err := ioutil.ReadFile(pth)
+	if err != nil {
+		return []byte{}, err
+	}
+	return bytes, nil
+}
+
+// ReadStringFromFile ...
+func ReadStringFromFile(pth string) (string, error) {
+	contBytes, err := ReadBytesFromFile(pth)
+	if err != nil {
+		return "", err
+	}
+	return string(contBytes), nil
+}
+
+// GetFileModeOfFile ...
+//  this is the "permissions" info, which can be passed directly to
+//  functions like WriteBytesToFileWithPermission or os.OpenFile
+func GetFileModeOfFile(pth string) (os.FileMode, error) {
+	finfo, err := os.Lstat(pth)
+	if err != nil {
+		return 0, err
+	}
+	return finfo.Mode(), nil
+}
+
+// GetFilePermissions ...
+// - alias of: GetFileModeOfFile
+//  this is the "permissions" info, which can be passed directly to
+//  functions like WriteBytesToFileWithPermission or os.OpenFile
+func GetFilePermissions(filePth string) (os.FileMode, error) {
+	return GetFileModeOfFile(filePth)
+}

--- a/vendor/github.com/bitrise-io/go-utils/log/internal_logger.go
+++ b/vendor/github.com/bitrise-io/go-utils/log/internal_logger.go
@@ -1,0 +1,76 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var (
+	analyticsServerURL = "https://bitrise-step-analytics.herokuapp.com"
+	httpClient         = http.Client{
+		Timeout: time.Second * 5,
+	}
+)
+
+// Entry represents a line in a log
+type Entry struct {
+	LogLevel string                 `json:"log_level"`
+	Message  string                 `json:"message"`
+	Data     map[string]interface{} `json:"data"`
+}
+
+// SetAnalyticsServerURL updates the the analytics server collecting the
+// logs. It is intended for use during tests. Warning: current implementation
+// is not thread safe, do not call the function during runtime.
+func SetAnalyticsServerURL(url string) {
+	analyticsServerURL = url
+}
+
+// Internal sends the log message to the configured analytics server
+func rprintf(logLevel string, stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
+	e := Entry{
+		Message:  fmt.Sprintf(format, v...),
+		LogLevel: logLevel,
+	}
+
+	e.Data = make(map[string]interface{})
+	for k, v := range data {
+		e.Data[k] = v
+	}
+
+	if v, ok := e.Data["step_id"]; ok {
+		fmt.Printf("internal logger: data.step_id (%s) will be overriden with (%s) ", v, stepID)
+	}
+	if v, ok := e.Data["tag"]; ok {
+		fmt.Printf("internal logger: data.tag (%s) will be overriden with (%s) ", v, tag)
+	}
+
+	e.Data["step_id"] = stepID
+	e.Data["tag"] = tag
+
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(e); err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequest(http.MethodPost, analyticsServerURL+"/logs", &b)
+	if err != nil {
+		// deliberately not writing into users log
+		return
+	}
+	req = req.WithContext(ctx)
+	req.Header.Add("Content-Type", "application/json")
+
+	if _, err := httpClient.Do(req); err != nil {
+		// deliberately not writing into users log
+		return
+	}
+
+}

--- a/vendor/github.com/bitrise-io/go-utils/log/json_logger.go
+++ b/vendor/github.com/bitrise-io/go-utils/log/json_logger.go
@@ -27,5 +27,7 @@ func NewDefaultJSONLoger() JSONLoger {
 
 // Print ...
 func (l JSONLoger) Print(f Formatable) {
-	fmt.Fprint(l.writer, f.JSON())
+	if _, err := fmt.Fprint(l.writer, f.JSON()); err != nil {
+		fmt.Printf("failed to print message: %s, error: %s\n", f.JSON(), err)
+	}
 }

--- a/vendor/github.com/bitrise-io/go-utils/log/print.go
+++ b/vendor/github.com/bitrise-io/go-utils/log/print.go
@@ -5,13 +5,24 @@ import (
 )
 
 func printf(severity Severity, withTime bool, format string, v ...interface{}) {
+	message := createLogMsg(severity, withTime, format, v...)
+	if _, err := fmt.Fprintln(outWriter, message); err != nil {
+		fmt.Printf("failed to print message: %s, error: %s\n", message, err)
+	}
+}
+
+func createLogMsg(severity Severity, withTime bool, format string, v ...interface{}) string {
 	colorFunc := severityColorFuncMap[severity]
 	message := colorFunc(format, v...)
 	if withTime {
-		message = fmt.Sprintf("%s %s", timestampField(), message)
+		message = prefixCurrentTime(message)
 	}
 
-	fmt.Fprintln(outWriter, message)
+	return message
+}
+
+func prefixCurrentTime(message string) string {
+	return fmt.Sprintf("%s %s", timestampField(), message)
 }
 
 // Successf ...
@@ -86,4 +97,19 @@ func TWarnf(format string, v ...interface{}) {
 // TErrorf ...
 func TErrorf(format string, v ...interface{}) {
 	printf(errorSeverity, true, format, v...)
+}
+
+// RInfof ...
+func RInfof(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
+	rprintf("info", stepID, tag, data, format, v...)
+}
+
+// RWarnf ...
+func RWarnf(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
+	rprintf("warn", stepID, tag, data, format, v...)
+}
+
+// RErrorf ...
+func RErrorf(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
+	rprintf("error", stepID, tag, data, format, v...)
 }

--- a/vendor/github.com/bitrise-io/go-utils/log/raw_logger.go
+++ b/vendor/github.com/bitrise-io/go-utils/log/raw_logger.go
@@ -27,5 +27,7 @@ func NewDefaultRawLogger() RawLogger {
 
 // Print ...
 func (l RawLogger) Print(f Formatable) {
-	fmt.Fprintln(l.writer, f.String())
+	if _, err := fmt.Fprintln(l.writer, f.String()); err != nil {
+		fmt.Printf("failed to print message: %s, error: %s\n", f.String(), err)
+	}
 }

--- a/vendor/github.com/bitrise-io/go-utils/pathutil/pathutil.go
+++ b/vendor/github.com/bitrise-io/go-utils/pathutil/pathutil.go
@@ -179,3 +179,8 @@ func NormalizedOSTempDirPath(tmpDirNamePrefix string) (retPth string, err error)
 	}
 	return
 }
+
+// GetFileName returns the name of the file from a given path or the name of the directory if it is a directory
+func GetFileName(path string) string {
+	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+}

--- a/vendor/github.com/bitrise-io/go-utils/pkcs12/LICENSE
+++ b/vendor/github.com/bitrise-io/go-utils/pkcs12/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2015, 2018, 2019 Opsmate, Inc. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Fixes error when Gemfile.lock is created with bundler v2:
```
You must use Bundler 2 or greater with this lockfile.
Failed to run bundle install, error: exit status 20
```