### PR TITLE
Add input for --fail-on-errors flag and update dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7f701bf493a03c4fb4c9f22c49048b2bef8484358846d125870f6891baf3e11d"
+  digest = "1:fd5934c9bc6497b3e56ee384eef8181e51b879189cd619d251b90e00141eb90d"
   name = "github.com/bitrise-io/go-utils"
   packages = [
     "colorstring",
@@ -18,15 +18,15 @@
     "pointers",
   ]
   pruneopts = "UT"
-  revision = "ad86bf775472ce1934affb9d3cb7d5ea3dffd16f"
+  revision = "5067a2a682f21030f379f88e853b9e0734a24516"
 
 [[projects]]
   branch = "master"
-  digest = "1:d9f47b0642c42512eefed4aad27c4daf41e9f3380087d302cd0a9f5612143856"
+  digest = "1:65497df2301289c26765c4cf8fcd4709de190dd620ea822ae2dc67edfc598307"
   name = "github.com/bitrise-tools/go-steputils"
   packages = ["stepconf"]
   pruneopts = "UT"
-  revision = "d4d9e08cc4347e8784bb18419fcdceb932e17019"
+  revision = "3c98d95a94d51624a26e99419d0fc03d2aab0055"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ type Config struct {
 	GitlabAPIToken   stepconf.Secret `env:"gitlab_api_token"`
 	GitlabHost       string          `env:"gitlab_host"`
 	GitlabAPIBaseURL string          `env:"gitlab_api_base_url"`
-	IsFailOnErrors   string          `env:"is_fail_on_errors,opt[true,false]"`
+	FailOnErrors     string          `env:"fail_on_errors,opt[true,false]"`
 }
 
 func validateInputs(cfg Config) {
@@ -84,7 +84,7 @@ func main() {
 		"DANGER_GITLAB_API_TOKEN":    string(cfg.GitlabAPIToken),
 		"DANGER_GITLAB_HOST":         cfg.GitlabHost,
 		"DANGER_GITLAB_API_BASE_URL": cfg.GitlabAPIBaseURL,
-		"DANGER_IS_FAIL_ON_ERRORS":   cfg.IsFailOnErrors,
+		"DANGER_FAIL_ON_ERRORS":      cfg.FailOnErrors,
 	} {
 		if value != "" {
 			if err := os.Setenv(key, value); err != nil {
@@ -140,7 +140,7 @@ func main() {
 	fmt.Println()
 	log.Infof("Running danger")
 
-	failOnErrorsFlag := fmt.Sprintf("--fail-on-errors=%s", cfg.IsFailOnErrors)
+	failOnErrorsFlag := fmt.Sprintf("--fail-on-errors=%s", cfg.FailOnErrors)
 	cmd = command.New("bundle", "exec", "danger", failOnErrorsFlag)
 	cmd.SetStdout(os.Stdout)
 	cmd.SetStderr(os.Stderr)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ type Config struct {
 	GitlabAPIToken   stepconf.Secret `env:"gitlab_api_token"`
 	GitlabHost       string          `env:"gitlab_host"`
 	GitlabAPIBaseURL string          `env:"gitlab_api_base_url"`
+	IsFailOnErrors   string          `env:"is_fail_on_errors,opt[true,false]"`
 }
 
 func validateInputs(cfg Config) {
@@ -83,6 +84,7 @@ func main() {
 		"DANGER_GITLAB_API_TOKEN":    string(cfg.GitlabAPIToken),
 		"DANGER_GITLAB_HOST":         cfg.GitlabHost,
 		"DANGER_GITLAB_API_BASE_URL": cfg.GitlabAPIBaseURL,
+		"DANGER_IS_FAIL_ON_ERRORS":   cfg.IsFailOnErrors,
 	} {
 		if value != "" {
 			if err := os.Setenv(key, value); err != nil {
@@ -138,7 +140,8 @@ func main() {
 	fmt.Println()
 	log.Infof("Running danger")
 
-	cmd = command.New("bundle", "exec", "danger", "--fail-on-errors=true")
+	failOnErrorsFlag := fmt.Sprintf("--fail-on-errors=%s", cfg.IsFailOnErrors)
+	cmd = command.New("bundle", "exec", "danger", failOnErrorsFlag)
 	cmd.SetStdout(os.Stdout)
 	cmd.SetStderr(os.Stderr)
 	log.Printf("$ %s", cmd.PrintableCommandArgs())

--- a/step.yml
+++ b/step.yml
@@ -109,3 +109,9 @@ inputs:
           **For example:** `https://git.corp.evilcorp.com/api/v4`
 
           **You can read more about it here:** [https://danger.systems/guides/getting_started.html](https://danger.systems/guides/getting_started.html)
+  - is_fail_on_errors: "true"
+    opts:
+      title: Is fail on errors enabled
+      description: --fail-on-errors flag value
+      value_options: ["true", "false"]
+      is_required: true

--- a/step.yml
+++ b/step.yml
@@ -109,9 +109,11 @@ inputs:
           **For example:** `https://git.corp.evilcorp.com/api/v4`
 
           **You can read more about it here:** [https://danger.systems/guides/getting_started.html](https://danger.systems/guides/getting_started.html)
-  - is_fail_on_errors: "true"
+  - fail_on_errors: "true"
     opts:
-      title: Is fail on errors enabled
-      description: --fail-on-errors flag value
-      value_options: ["true", "false"]
+      title: Fail on errors
+      description: Marks the step as failed if Danger reports any issues
+      value_options: 
+        - "true"
+        - "false"
       is_required: true

--- a/vendor/github.com/bitrise-io/go-utils/command/file.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/file.go
@@ -33,6 +33,7 @@ func CopyDir(src, dst string, isOnlyContent bool) error {
 }
 
 // RemoveDir ...
+// Deprecated: use RemoveAll instead.
 func RemoveDir(dirPth string) error {
 	if exist, err := pathutil.IsPathExists(dirPth); err != nil {
 		return err
@@ -45,11 +46,22 @@ func RemoveDir(dirPth string) error {
 }
 
 // RemoveFile ...
+// Deprecated: use RemoveAll instead.
 func RemoveFile(pth string) error {
 	if exist, err := pathutil.IsPathExists(pth); err != nil {
 		return err
 	} else if exist {
 		if err := os.Remove(pth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveAll removes recursively every file on the given paths.
+func RemoveAll(pths ...string) error {
+	for _, pth := range pths {
+		if err := os.RemoveAll(pth); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/bitrise-io/go-utils/command/rubycommand/rubycommand.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/rubycommand/rubycommand.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/pathutil"
 )
 
 const (
@@ -46,7 +47,8 @@ func cmdExist(slice ...string) bool {
 	return (cmd.Run() == nil)
 }
 
-func installType() InstallType {
+// RubyInstallType returns which version manager was used for the ruby install
+func RubyInstallType() InstallType {
 	whichRuby, err := command.New("which", "ruby").RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		return Unkown
@@ -103,7 +105,7 @@ func sudoNeeded(installType InstallType, slice ...string) bool {
 
 // NewWithParams ...
 func NewWithParams(params ...string) (*command.Model, error) {
-	rubyInstallType := installType()
+	rubyInstallType := RubyInstallType()
 	if rubyInstallType == Unkown {
 		return nil, errors.New("unknown ruby installation type")
 	}
@@ -137,7 +139,7 @@ func GemUpdate(gem string) ([]*command.Model, error) {
 
 	cmds = append(cmds, cmd)
 
-	rubyInstallType := installType()
+	rubyInstallType := RubyInstallType()
 	if rubyInstallType == RbenvRuby {
 		cmd, err := New("rbenv", "rehash")
 		if err != nil {
@@ -166,7 +168,7 @@ func GemInstall(gem, version string) ([]*command.Model, error) {
 
 	cmds = append(cmds, cmd)
 
-	rubyInstallType := installType()
+	rubyInstallType := RubyInstallType()
 	if rubyInstallType == RbenvRuby {
 		cmd, err := New("rbenv", "rehash")
 		if err != nil {
@@ -208,8 +210,61 @@ func IsGemInstalled(gem, version string) (bool, error) {
 
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("%s: error: %s", out, err)
 	}
 
 	return findGemInList(out, gem, version)
+}
+
+func isSpecifiedRbenvRubyInstalled(message string) (bool, string, error) {
+	//
+	// Not installed
+	reg, err := regexp.Compile("rbenv: version \x60.*' is not installed") // \x60 == ` (The go linter suggested to use the hex code instead)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse regex ( %s ) on the error message, error: %s", "rbenv: version \x60.*' is not installed", err) // \x60 == ` (The go linter suggested to use the hex code instead)
+	}
+
+	var version string
+	if reg.MatchString(message) {
+		message := reg.FindString(message)
+		version = strings.Split(strings.Split(message, "`")[1], "'")[0]
+		return false, version, nil
+	}
+
+	//
+	// Installed
+	reg, err = regexp.Compile(".* \\(set by")
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse regex ( %s ) on the error message, error: %s", ".* \\(set by", err)
+	}
+
+	if reg.MatchString(message) {
+		s := reg.FindString(message)
+		version = strings.Split(s, " (set by")[0]
+		return true, version, nil
+	}
+	return false, version, nil
+}
+
+// IsSpecifiedRbenvRubyInstalled checks if the selected ruby version is installed via rbenv.
+// Ruby version is set by
+// 1. The RBENV_VERSION environment variable
+// 2. The first .ruby-version file found by searching the directory of the script you are executing and each of its
+// parent directories until reaching the root of your filesystem.
+// 3.The first .ruby-version file found by searching the current working directory and each of its parent directories
+// until reaching the root of your filesystem.
+// 4. The global ~/.rbenv/version file. You can modify this file using the rbenv global command.
+// src: https://github.com/rbenv/rbenv#choosing-the-ruby-version
+func IsSpecifiedRbenvRubyInstalled(workdir string) (bool, string, error) {
+	absWorkdir, err := pathutil.AbsPath(workdir)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get absolute path for ( %s ), error: %s", workdir, err)
+	}
+
+	cmd := command.New("rbenv", "version").SetDir(absWorkdir)
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		return false, "", fmt.Errorf("failed to check installed ruby version, %s error: %s", out, err)
+	}
+	return isSpecifiedRbenvRubyInstalled(out)
 }

--- a/vendor/github.com/bitrise-io/go-utils/log/severity.go
+++ b/vendor/github.com/bitrise-io/go-utils/log/severity.go
@@ -20,7 +20,7 @@ var (
 	successSeverityColorFunc severityColorFunc = colorstring.Greenf
 	infoSeverityColorFunc    severityColorFunc = colorstring.Bluef
 	normalSeverityColorFunc  severityColorFunc = colorstring.NoColorf
-	debugSeverityColorFunc   severityColorFunc = colorstring.NoColorf
+	debugSeverityColorFunc   severityColorFunc = colorstring.Magentaf
 	warnSeverityColorFunc    severityColorFunc = colorstring.Yellowf
 	errorSeverityColorFunc   severityColorFunc = colorstring.Redf
 )

--- a/vendor/github.com/bitrise-tools/go-steputils/stepconf/stepconf.go
+++ b/vendor/github.com/bitrise-tools/go-steputils/stepconf/stepconf.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/parseutil"
 )
 
@@ -22,6 +22,12 @@ type ParseError struct {
 	Value string
 	Err   error
 }
+
+const rangeMinimumGroupName = "min"
+const rangeMaximumGroupName = "max"
+const rangeMinBracketGroupName = "minbr"
+const rangeMaxBracketGroupName = "maxbr"
+const rangeRegex = `range(?P<` + rangeMinBracketGroupName + `>\[|\])(?P<` + rangeMinimumGroupName + `>.*?)\.\.(?P<` + rangeMaximumGroupName + `>.*?)(?P<` + rangeMaxBracketGroupName + `>\[|\])`
 
 // Error implements builtin errors.Error.
 func (e *ParseError) Error() string {
@@ -47,16 +53,44 @@ func (s Secret) String() string {
 	return secret
 }
 
-// Print the name of the struct in blue color followed by a newline,
+// Print the name of the struct with Title case in blue color with followed by a newline,
 // then print all fields formatted as '- field name: field value` separated by newline.
 func Print(config interface{}) {
+	fmt.Printf(toString(config))
+}
+
+func valueString(v reflect.Value) string {
+	if v.Kind() != reflect.Ptr {
+		return fmt.Sprintf("%v", v.Interface())
+	}
+
+	if !v.IsNil() {
+		return fmt.Sprintf("%v", v.Elem().Interface())
+	}
+
+	return ""
+}
+
+// returns the name of the struct with Title case in blue color followed by a newline,
+// then print all fields formatted as '- field name: field value` separated by newline.
+func toString(config interface{}) string {
 	v := reflect.ValueOf(config)
 	t := reflect.TypeOf(config)
 
-	log.Infof("%s:", t.Name())
-	for i := 0; i < t.NumField(); i++ {
-		fmt.Printf("- %s: %v\n", t.Field(i).Name, v.Field(i).Interface())
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
 	}
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	str := fmt.Sprintf(colorstring.Bluef("%s:\n", strings.Title(t.Name())))
+	for i := 0; i < t.NumField(); i++ {
+		str += fmt.Sprintf("- %s: %s\n", t.Field(i).Name, valueString(v.Field(i)))
+	}
+
+	return str
 }
 
 // parseTag splits a struct field's env tag into its name and option.
@@ -98,6 +132,8 @@ func Parse(conf interface{}) error {
 		for _, err := range errs {
 			errorString += fmt.Sprintf("\n- %s", err)
 		}
+
+		errorString += fmt.Sprintf("\n\n%s", toString(conf))
 		return errors.New(errorString)
 	}
 
@@ -105,29 +141,20 @@ func Parse(conf interface{}) error {
 }
 
 func setField(field reflect.Value, value, constraint string) error {
-	switch constraint {
-	case "":
-		break
-	case "required":
-		if value == "" {
-			return errors.New("required variable is not present")
-		}
-	case "file", "dir":
-		if err := checkPath(value, constraint == "dir"); err != nil {
-			return err
-		}
-	// TODO: use FindStringSubmatch to distinguish no match and match for empty string.
-	case regexp.MustCompile(`^opt\[.*\]$`).FindString(constraint):
-		if !contains(value, constraint) {
-			// TODO: print only the value options, not the whole string.
-			return fmt.Errorf("value is not in value options (%s)", constraint)
-		}
-	default:
-		return fmt.Errorf("invalid constraint (%s)", constraint)
+	if err := validateConstraint(value, constraint); err != nil {
+		return err
 	}
 
 	if value == "" {
 		return nil
+	}
+
+	if field.Kind() == reflect.Ptr {
+		// If field is a pointer type, then set its value to be a pointer to a new zero value, matching field underlying type.
+		var dePtrdType = field.Type().Elem()     // get the type field can point to
+		var newPtrType = reflect.New(dePtrdType) // create new ptr address for type with non-nil zero value
+		field.Set(newPtrType)                    // assign value to pointer
+		field = field.Elem()
 	}
 
 	switch field.Kind() {
@@ -145,12 +172,300 @@ func setField(field reflect.Value, value, constraint string) error {
 			return errors.New("can't convert to int")
 		}
 		field.SetInt(n)
+	case reflect.Float64:
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return errors.New("can't convert to float")
+		}
+		field.SetFloat(f)
 	case reflect.Slice:
 		field.Set(reflect.ValueOf(strings.Split(value, "|")))
 	default:
 		return fmt.Errorf("type is not supported (%s)", field.Kind())
 	}
 	return nil
+}
+
+func validateConstraint(value, constraint string) error {
+	switch constraint {
+	case "":
+		break
+	case "required":
+		if value == "" {
+			return errors.New("required variable is not present")
+		}
+	case "file", "dir":
+		if err := checkPath(value, constraint == "dir"); err != nil {
+			return err
+		}
+	// TODO: use FindStringSubmatch to distinguish no match and match for empty string.
+	case regexp.MustCompile(`^opt\[.*\]$`).FindString(constraint):
+		if !contains(value, constraint) {
+			// TODO: print only the value options, not the whole string.
+			return fmt.Errorf("value is not in value options (%s)", constraint)
+		}
+	case regexp.MustCompile(rangeRegex).FindString(constraint):
+		if err := ValidateRangeFields(value, constraint); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid constraint (%s)", constraint)
+	}
+	return nil
+}
+
+//ValidateRangeFields validates if the given range is proper. Ranges are optional, empty values are valid.
+func ValidateRangeFields(valueStr, constraint string) error {
+	if valueStr == "" {
+		return nil
+	}
+	constraintMin, constraintMax, constraintMinBr, constraintMaxBr, err := GetRangeValues(constraint)
+	if err != nil {
+		return err
+	}
+	min, err := parseValueStr(constraintMin)
+	if err != nil {
+		return fmt.Errorf("failed to parse min value %s: %s", constraintMin, err)
+	}
+	max, err := parseValueStr(constraintMax)
+	if err != nil {
+		return fmt.Errorf("failed to parse max value %s: %s", constraintMax, err)
+	}
+	value, err := parseValueStr(valueStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse value %s: %s", valueStr, err)
+	}
+	isMinInclusiveBool, err := isMinInclusive(constraintMinBr)
+	if err != nil {
+		return err
+	}
+	isMaxInclusiveBool, err := isMaxInclusive(constraintMaxBr)
+	if err != nil {
+		return err
+	}
+
+	if err := validateRangeFieldValues(min, max, isMinInclusiveBool, isMaxInclusiveBool, value); err != nil {
+		return err
+	}
+	if err := validateRangeFieldTypes(min, max, value); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isMinInclusive(bracket string) (bool, error) {
+	switch bracket {
+	case "[":
+		return true, nil
+	case "]":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid string found for bracket: %s", bracket)
+	}
+}
+
+func isMaxInclusive(bracket string) (bool, error) {
+	switch bracket {
+	case "[":
+		return false, nil
+	case "]":
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid string found for bracket: %s", bracket)
+	}
+}
+
+func validateRangeFieldValues(min interface{}, max interface{}, minInclusive bool, maxInclusive bool, value interface{}) error {
+	if value == nil {
+		return fmt.Errorf("value is not present")
+	}
+	var err error
+	var valueFloat float64
+	if valueFloat, err = getFloatValue(value); err != nil {
+		return err
+	}
+
+	var minErr error
+	var minFloat float64
+	if min != nil {
+		if minFloat, err = getFloatValue(min); err != nil {
+			return err
+		}
+		minErr = validateRangeMinFieldValue(minFloat, valueFloat, minInclusive)
+	}
+
+	var maxErr error
+	var maxFloat float64
+	if max != nil {
+		var err error
+		if maxFloat, err = getFloatValue(max); err != nil {
+			return err
+		}
+		maxErr = validateRangeMaxFieldValue(maxFloat, valueFloat, maxInclusive)
+	}
+
+	if min != nil && max != nil {
+		if minFloat > maxFloat {
+			return fmt.Errorf("constraint logic is wrong, minimum value %f is bigger than maximum %f", minFloat, maxFloat)
+		}
+		if minFloat == maxFloat {
+			return fmt.Errorf("minimum value %f is equal to maximum %f, for this case use optional value", minFloat, maxFloat)
+		}
+	}
+
+	if min == nil {
+		return maxErr
+	} else if max == nil {
+		return minErr
+	}
+	if minErr != nil || maxErr != nil {
+		return fmt.Errorf("value %f is out of range %f-%f", value, minFloat, maxFloat)
+	}
+	return nil
+}
+
+func validateRangeFieldTypes(min interface{}, max interface{}, value interface{}) error {
+	if value == nil {
+		return fmt.Errorf("value cannot be nil")
+	}
+	var minType string
+	var maxType string
+	var valueType string
+	var err error
+
+	if valueType, err = getTypeOf(value); err != nil {
+		return err
+	}
+	if min != nil {
+		if minType, err = getTypeOf(min); err != nil {
+			return err
+		}
+	}
+	if max != nil {
+		if maxType, err = getTypeOf(max); err != nil {
+			return err
+		}
+	}
+
+	if maxType != "" && minType != "" && !hasSameContent(minType, maxType, valueType) {
+		return fmt.Errorf("invalid constraint and value combination, minimum is %s, maximum is %s, value is %s, but they should be the same", minType, maxType, valueType)
+	}
+
+	if maxType != "" && !hasSameContent(maxType, valueType) {
+		return fmt.Errorf("invalid constraint and value combination, maximum is %s, value is %s, but they should be the same", maxType, valueType)
+	}
+
+	if minType != "" && !hasSameContent(minType, valueType) {
+		return fmt.Errorf("invalid constraint and value combination, minimum is %s, value is %s, but they should be the same", minType, valueType)
+	}
+	return nil
+}
+
+func hasSameContent(strs ...string) bool {
+	length := len(strs)
+	if length == 1 {
+		return true
+	}
+	firstItem := strs[0]
+	for i := 1; i < length; i++ {
+		if strings.Compare(firstItem, strs[i]) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func getTypeOf(v interface{}) (string, error) {
+	switch v.(type) {
+	case int64:
+		return "int64", nil
+	case float64:
+		return "float64", nil
+	default:
+		return "unknown", fmt.Errorf("could not find type for %v", v)
+	}
+}
+
+func parseValueStr(value string) (interface{}, error) {
+	var err error
+	var parsedInt int64
+	var parsedFloat float64
+	if parsedInt, err = strconv.ParseInt(value, 10, 64); err != nil {
+		// Could be float
+		if parsedFloat, err = strconv.ParseFloat(value, 64); err != nil {
+			// It is invalid.
+			return nil, fmt.Errorf("value %s is could not be parsed", value)
+		}
+		return parsedFloat, nil
+	}
+	return parsedInt, nil
+}
+
+func getFloatValue(value interface{}) (float64, error) {
+	switch i := value.(type) {
+	case int64:
+		return float64(i), nil
+	case float64:
+		return i, nil
+	case string:
+		var parsedValue interface{}
+		var err error
+		if parsedValue, err = parseValueStr(i); err != nil {
+			return 0, err
+		}
+		return getFloatValue(parsedValue)
+	default:
+		return 0, fmt.Errorf("not supported type %T", value)
+	}
+}
+
+func validateRangeMinFieldValue(min float64, value float64, inclusive bool) error {
+	if inclusive && min > value {
+		return fmt.Errorf("value %f is out of range, less than minimum %f", value, min)
+	} else if !inclusive && min >= value {
+		return fmt.Errorf("value %f is out of range, greater or equal than maximum %f", value, min)
+	}
+	return nil
+}
+
+func validateRangeMaxFieldValue(max float64, value float64, inclusive bool) error {
+	if inclusive && max < value {
+		return fmt.Errorf("value %f is out of range, greater than maximum %f", value, max)
+
+	} else if !inclusive && max <= value {
+		return fmt.Errorf("value %f is out of range, greater or equal than maximum %f", value, max)
+	}
+	return nil
+}
+
+// GetRangeValues reads up the given range constraint and returns the values, or an error if the constraint is malformed or could not be parsed.
+func GetRangeValues(value string) (min string, max string, minBracket string, maxBracket string, err error) {
+	regex := regexp.MustCompile(rangeRegex)
+	groups := regex.FindStringSubmatch(value)
+	if len(groups) < 1 {
+		return "", "", "", "", fmt.Errorf("value in value options is malformed (%s)", value)
+	}
+
+	groupMap := getRegexGroupMap(groups, regex)
+	minStr := groupMap[rangeMinimumGroupName]
+	maxStr := groupMap[rangeMaximumGroupName]
+	minBr := groupMap[rangeMinBracketGroupName]
+	maxBr := groupMap[rangeMaxBracketGroupName]
+	if minStr == "" && maxStr == "" {
+		return "", "", "", "", fmt.Errorf("constraint contains no limits")
+	}
+	return minStr, maxStr, minBr, maxBr, nil
+}
+
+func getRegexGroupMap(groups []string, regex *regexp.Regexp) map[string]string {
+	result := make(map[string]string)
+	for i, value := range regex.SubexpNames() {
+		if i != 0 && value != "" {
+			result[value] = groups[i]
+		}
+	}
+	return result
 }
 
 func checkPath(path string, dir bool) error {


### PR DESCRIPTION
In the #4 `--fail-on-errors=true` flag was introduced, but its value was hardcoded, this PR introduces this flag value as an input. (10c88be)

On this page:  https://discuss.bitrise.io/t/run-danger-v1-0-0/10316 there is a workaround:
> Set is_skippable: true on the step to revert the previous behavior. 

However `is_skippable` flag isn’t always good option, because when this step was failed from other reason than danger fail then `is_skippable: true` could hide the real problem, eg. missing/invalid github/gitlab api token.

Also updated dependencies.